### PR TITLE
Mostly updates on Markdown rendering

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -208,7 +208,7 @@ kramdown:
   entity_output: as_char
   toc_levels: 1..6
   smart_quotes: lsquo,rsquo,ldquo,rdquo
-  enable_coderay: false
+  syntax_highlighter: true
 
 
 # Sass/SCSS

--- a/docs/_layouts/fa_project.html
+++ b/docs/_layouts/fa_project.html
@@ -150,7 +150,7 @@ layout: default
                 </div>
                 <div class="mt-5 py-5 border-top text-start">
                    <div class="row justify-content-start">
-                      <div class="col-lg-12">
+                      <div class="col-lg-12 readme-content">
                         {{content | markdownify}}
                       </div>
                    </div>

--- a/docs/_layouts/fa_project.html
+++ b/docs/_layouts/fa_project.html
@@ -4,7 +4,7 @@ layout: default
 
 <main class="profile-page">
     <section class="section-profile-cover section-shaped my-0">
-       <div class="shape shape-style-1 shape-primary alpha-4"> 
+       <div class="shape shape-style-1 shape-primary alpha-4">
           <span></span>
           <span></span>
           <span></span>
@@ -150,8 +150,8 @@ layout: default
                 </div>
                 <div class="mt-5 py-5 border-top text-start">
                    <div class="row justify-content-start">
-                      <div class="col-lg-9">
-                        {{content |markdownify}}
+                      <div class="col-lg-12">
+                        {{content | markdownify}}
                       </div>
                    </div>
                 </div>

--- a/docs/_projects/fa_git_flutter_blue.md
+++ b/docs/_projects/fa_git_flutter_blue.md
@@ -136,14 +136,16 @@ characteristic.value.listen((value) {
 ```
 
 ## Reference
-### FlutterBlue API
-|                  |      Android       |         iOS          |             Description            |
+### FlutterBlue API]
+
+| State |      Android       |         iOS          |             Description            |
 | :--------------- | :----------------: | :------------------: |  :-------------------------------- |
 | scan             | :white_check_mark: |  :white_check_mark:  | Starts a scan for Bluetooth Low Energy devices. |
 | state            | :white_check_mark: |  :white_check_mark:  | Gets the current state of the Bluetooth Adapter. |
 | onStateChanged   | :white_check_mark: |  :white_check_mark:  | Stream of state changes for the Bluetooth Adapter. |
 
 ### BluetoothDevice API
+
 |                             |       Android        |         iOS          |             Description            |
 | :-------------------------- | :------------------: | :------------------: |  :-------------------------------- |
 | connect                     |  :white_check_mark:  |  :white_check_mark:  | Establishes a connection to the device. |
@@ -154,6 +156,7 @@ characteristic.value.listen((value) {
 | onStateChanged              |  :white_check_mark:  |  :white_check_mark:  | Notifies of state changes for the device. |
 
 ### BluetoothCharacteristic API
+
 |                             |       Android        |         iOS          |             Description            |
 | :-------------------------- | :------------------: | :------------------: |  :-------------------------------- |
 | read                        |  :white_check_mark:  |  :white_check_mark:  | Retrieves the value of the characteristic.  |
@@ -162,6 +165,8 @@ characteristic.value.listen((value) {
 | value                       |  :white_check_mark:  |  :white_check_mark:  | Stream of characteristic's value when changed. |
 
 ### BluetoothDescriptor API
+
+
 |                             |       Android        |         iOS          |             Description            |
 | :-------------------------- | :------------------: | :------------------: |  :-------------------------------- |
 | read                        |  :white_check_mark:  |  :white_check_mark:  | Retrieves the value of the descriptor.  |

--- a/docs/_projects/fa_git_flutter_blue.md
+++ b/docs/_projects/fa_git_flutter_blue.md
@@ -136,7 +136,7 @@ characteristic.value.listen((value) {
 ```
 
 ## Reference
-### FlutterBlue API]
+### FlutterBlue API
 
 | State |      Android       |         iOS          |             Description            |
 | :--------------- | :----------------: | :------------------: |  :-------------------------------- |

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -23,5 +23,9 @@
         font-weight: 600;
         line-height: 20px;
         padding: 6px 12px;
-    
+
+}
+
+.readme-content table{
+  width: 80vw;
 }

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -29,3 +29,8 @@
 .readme-content table{
   width: 80vw;
 }
+
+.readme-content img {
+  max-width: 100%;
+}
+


### PR DESCRIPTION
- fix for #47 
Added newline before each table starts in markdown fixes it.

- Custom css for tables and img tags in markdown (#37 )
Added width as 80% for `table` tag.
Set max-width as 100% for `img` tag
