### PR TITLE
Staticman v3 config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,7 @@ name                     : "FlutterArsenal"
 description              : "A categorized directory of libraries and tools for Flutter"
 url                      : # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : # the subpath of your site, e.g. "/blog"
-repository               : # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
+repository               : "flutterarsenal/FlutterArsenal" # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
 teaser                   : "/assets/img/brand/white.png" # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 logo                     : # path of logo image to display in the masthead, e.g. "/assets/images/88x88.png"
 masthead_title           : # overrides the website title displayed in the masthead, use " " for no title
@@ -44,7 +44,7 @@ comments:
     issue_term           : # "pathname" (default)
 staticman:
   allowedFields          : # ['name', 'email', 'url', 'message']
-  branch                 : # "master"
+  branch                 : "master"
   commitMessage          : # "New comment by {fields.name}"
   filename               : # comment-{@timestamp}
   format                 : # "yml"
@@ -58,10 +58,10 @@ staticman:
       type               : # "date"
       options:
         format           : # "iso8601" (default), "timestamp-seconds", "timestamp-milliseconds"
-  endpoint               : # URL of your own deployment with trailing slash, will fallback to the public instance
+  endpoint               : "https://staticman.flutterarsenal.com/v3/entry/github" # URL of your own deployment with trailing slash, will fallback to the public instance
 reCaptcha:
-  siteKey                :
-  secret                 :
+  siteKey                : "6LdRBykTAAAAAFB46MnIu6ixuxwu9W1ihFF8G60Q"
+  secret                 : "PznnZGu3P6eTHRPLORniSq+J61YEf+A9zmColXDM5icqF49gbunH51B8+h+i2IvewpuxtA9TFoK68TuhUp/X3YKmmqhXasegHYabY50fqF9nJh9npWNhvITdkQHeaOqnFXUIwxfiEeUt49Yoa2waRR7a5LdRAP3SVM8hz0KIBT4="
 atom_feed:
   path                   : # blank (default) uses feed.xml
 search                   : true # true, false (default)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -58,7 +58,7 @@ staticman:
       type               : # "date"
       options:
         format           : # "iso8601" (default), "timestamp-seconds", "timestamp-milliseconds"
-  endpoint               : "https://staticman.flutterarsenal.com/v3/entry/github" # URL of your own deployment with trailing slash, will fallback to the public instance
+  endpoint               : "https://staticman.flutterarsenal.com/v3/entry/github/" # URL of your own deployment with trailing slash, will fallback to the public instance
 reCaptcha:
   siteKey                : "6LdRBykTAAAAAFB46MnIu6ixuxwu9W1ihFF8G60Q"
   secret                 : "PznnZGu3P6eTHRPLORniSq+J61YEf+A9zmColXDM5icqF49gbunH51B8+h+i2IvewpuxtA9TFoK68TuhUp/X3YKmmqhXasegHYabY50fqF9nJh9npWNhvITdkQHeaOqnFXUIwxfiEeUt49Yoa2waRR7a5LdRAP3SVM8hz0KIBT4="


### PR DESCRIPTION
Resolve #46.  Note that apart from this PR, you need additional steps to hook up this repo with your custom API instance in the repo settings.  The actual procedures vary, depending on the Git commit SHA1 hash of your API's source code, and are *not* fully documented in the official site.

Modifications on theme config:

1. `endpoint`: introduced in Minimal Mistakes PR 1845, it defaults to `https://api.staticman.net/v2/entry/`.  The corresponding GitHub bot is @staticmanapp, which has recently (and silently) stopped its service.
https://github.com/flutterarsenal/FlutterArsenal/blob/e36c94636c29b2b12e6754a2e10bc006b18ddf53/docs/_includes/comments.html#L38
    - The domain name in this PR comes from https://github.com/flutterarsenal/FlutterArsenal/issues/46#issuecomment-514446046.
    - Staticman v3 URL scheme comes from Staticman PR 219.
    - In the 1st commit, I carelessly omitted the trailing slash while editing online.  Since it's found in the default value of `endpoint` in the above code block, I made the 2nd commit to fix that.
2. `branch` and `repository`: must have to get Staticman working.
https://github.com/flutterarsenal/FlutterArsenal/blob/e36c94636c29b2b12e6754a2e10bc006b18ddf53/docs/_includes/comments.html#L13-L17
3. reCAPTCHA: The displayed checkbox get the parameters from the theme config file. https://github.com/flutterarsenal/FlutterArsenal/blob/e36c94636c29b2b12e6754a2e10bc006b18ddf53/docs/_includes/comments.html#L73-L77
Therefore, reCAPTCHA parameters need to be set twice: once in Staticman config, once in theme config.
https://github.com/flutterarsenal/FlutterArsenal/blob/a2ca1f72eac898bd46e7d6997d32f3fea5f81dde/staticman.yml#L97-L104